### PR TITLE
Make const enum declarations

### DIFF
--- a/templates/enum.dust
+++ b/templates/enum.dust
@@ -1,6 +1,5 @@
 declare module {fullPackageName} {
-
-	export enum {name} {
+	export const enum {name} {
 		{#values}{name} = {id},
 		{/values}
 	}


### PR DESCRIPTION
In order to avoid issues like
https://github.com/Microsoft/TypeScript/issues/3548, it seems better to
generate const enums.