### PR TITLE
Add support for proto3 oneof

### DIFF
--- a/command.js
+++ b/command.js
@@ -1,34 +1,40 @@
-#!/usr/bin/env node
-
 /// <reference path="./definitions/node.d.ts" />
 /// <reference path="./definitions/dustjs-linkedin.d.ts" />
-var argv = require('optimist').usage('Convert a ProtoBuf.js JSON description in TypeScript definitions.\nUsage: $0').demand('f').alias('f', 'file').describe('f', 'The JSON file').boolean('c').alias('c', 'camelCaseGetSet').describe('c', 'Generate getter and setters in camel case notation').default('c', true).boolean('u').alias('u', 'underscoreGetSet').describe('u', 'Generate getter and setters in underscore notation').default('u', false).boolean('p').alias('p', 'properties').describe('p', 'Generate properties').default('p', true).argv;
-
+"use strict";
+var argv = require('optimist')
+    .usage('Convert a ProtoBuf.js JSON description in TypeScript definitions.\nUsage: $0')
+    .demand('f')
+    .alias('f', 'file')
+    .describe('f', 'The JSON file')
+    .boolean('c')
+    .alias('c', 'camelCaseGetSet')
+    .describe('c', 'Generate getter and setters in camel case notation')
+    .default('c', true)
+    .boolean('u')
+    .alias('u', 'underscoreGetSet')
+    .describe('u', 'Generate getter and setters in underscore notation')
+    .default('u', false)
+    .boolean('p')
+    .alias('p', 'properties')
+    .describe('p', 'Generate properties')
+    .default('p', true)
+    .argv;
 // Import in typescript and commondjs style
 //var ProtoBuf = require("protobufjs");
 var DustJS = require("dustjs-linkedin");
 var fs = require("fs");
-
 // Keep line breaks
-DustJS.optimizers.format = function (ctx, node) {
-    return node;
-};
-
+DustJS.optimizers.format = function (ctx, node) { return node; };
 // Create view filters
 DustJS.filters["firstLetterInUpperCase"] = function (value) {
     return value.charAt(0).toUpperCase() + value.slice(1);
 };
-
 DustJS.filters["firstLetterInLowerCase"] = function (value) {
     return value.charAt(0).toLowerCase() + value.slice(1);
 };
-
 DustJS.filters["camelCase"] = function (value) {
-    return value.replace(/(_[a-zA-Z])/g, function (match) {
-        return match[1].toUpperCase();
-    });
+    return value.replace(/(_[a-zA-Z])/g, function (match) { return match[1].toUpperCase(); });
 };
-
 DustJS.filters["convertType"] = function (value) {
     switch (value.toLowerCase()) {
         case 'string':
@@ -51,37 +57,24 @@ DustJS.filters["convertType"] = function (value) {
         case 'sfixed64':
             return "number";
     }
-
     // By default, it's a message identifier
     return value;
 };
-
-DustJS.filters["optionalFieldDeclaration"] = function (value) {
-    return value == "optional" ? "?" : "";
-};
-
-DustJS.filters["repeatedType"] = function (value) {
-    return value == "repeated" ? "[]" : "";
-};
-
+DustJS.filters["optionalFieldDeclaration"] = function (value) { return value == "optional" ? "?" : ""; };
+DustJS.filters["repeatedType"] = function (value) { return value == "repeated" ? "[]" : ""; };
 function loadDustTemplate(name) {
-    var template = fs.readFileSync(__dirname+"/templates/" + name + ".dust", "UTF8").toString(), compiledTemplate = DustJS.compile(template, name);
-
+    var template = fs.readFileSync(__dirname + "/templates/" + name + ".dust", "UTF8").toString(), compiledTemplate = DustJS.compile(template, name);
     DustJS.loadSource(compiledTemplate);
 }
-
 // Generate the names for the model, the types, and the interfaces
 function generateNames(model, prefix, name) {
-    if (typeof name === "undefined") { name = ""; }
+    if (name === void 0) { name = ""; }
     model.fullPackageName = prefix + (name != "." ? name : "");
-
     // Copies the settings (I'm lazy)
     model.properties = argv.properties;
     model.camelCaseGetSet = argv.camelCaseGetSet;
     model.underscoreGetSet = argv.underscoreGetSet;
-
     var newDefinitions = {};
-
     // Generate names for messages
     // Recursive call for all messages
     var key;
@@ -90,20 +83,25 @@ function generateNames(model, prefix, name) {
         newDefinitions[message.name] = "Builder";
         generateNames(message, model.fullPackageName, "." + (model.name ? model.name : ""));
     }
-
+    // Generate names for enums
     for (key in model.enums) {
         var currentEnum = model.enums[key];
         newDefinitions[currentEnum.name] = "";
         currentEnum.fullPackageName = model.fullPackageName + (model.name ? "." + model.name : "");
     }
-
+    // For fields of types which are defined in the same message,
+    // update the field type in consequence
     for (key in model.fields) {
         var field = model.fields[key];
         if (typeof newDefinitions[field.type] !== "undefined") {
             field.type = model.name + "." + field.type;
         }
     }
-
+    model.oneofsArray = [];
+    for (key in model.oneofs) {
+        var oneof = model.oneofs[key];
+        model.oneofsArray.push({ name: key, value: oneof });
+    }
     // Add the new definitions in the model for generate builders
     var definitions = [];
     for (key in newDefinitions) {
@@ -111,31 +109,26 @@ function generateNames(model, prefix, name) {
     }
     model.definitions = definitions;
 }
-
 // Load dust templates
 loadDustTemplate("module");
 loadDustTemplate("interface");
 loadDustTemplate("enum");
 loadDustTemplate("builder");
-
 // Load the json file
 var model = JSON.parse(fs.readFileSync(argv.file).toString());
-
 // If a packagename isn't present, use a default package name
 if (!model.package) {
     model.package = "Proto2TypeScript";
 }
-
 // Generates the names of the model
 generateNames(model, model.package);
-
 // Render the model
 DustJS.render("module", model, function (err, out) {
     if (err != null) {
         console.error(err);
         process.exit(1);
-    } else {
+    }
+    else {
         console.log(out);
     }
 });
-//# sourceMappingURL=command.js.map

--- a/command.ts
+++ b/command.ts
@@ -120,6 +120,13 @@ function generateNames (model : any, prefix : string, name : string = "") : void
 			field.type = model.name + "." + field.type;
 		}
 	}
+	
+	model.oneofsArray = [];
+	
+	for (key in model.oneofs) {
+		var oneof = model.oneofs[key];
+		model.oneofsArray.push({name: key, value: oneof});
+	}
 
 	// Add the new definitions in the model for generate builders
 	var definitions: any[] = [];

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
     "proto2ts": "command.js"
   },
   "dependencies": {
-    "optimist": "^0.6.1",
     "dustjs-linkedin": "^2.3.3",
-    "protobufjs": "^2.0.5"
+    "optimist": "^0.6.1",
+    "protobufjs": "^5.0.0"
   },
   "devDependencies": {
     "expect.js": "~0.3.1",
-    "mocha": "^1.17.1"
+    "mocha": "^1.17.1",
+    "typescript": "^1.7.5"
   },
   "repository": {
     "type": "git",

--- a/runTests.sh
+++ b/runTests.sh
@@ -2,27 +2,34 @@
 
 set -e # abort on the first error
 
+TSC=`npm bin`/tsc
+MOCHA=`npm bin`/mocha
+
 for f in tests/*.proto
 do
 	fileName=${f%.*}
 	
+	echo "Running pbjs $f"
+	
 	# Convert the prototype file
-	./node_modules/protobufjs/bin/proto2js $f > $fileName.json
+	./node_modules/protobufjs/bin/pbjs $f > $fileName.json
+
+	echo "Running command.js $fileName.json"
 
 	# Start the program (it should work)
 	echo "/// <reference path=\"../definitions/bytebuffer.d.ts\" />" > $fileName.d.ts
 	node command.js -f $fileName.json >> $fileName.d.ts
 
 	# Run the TypeScript compiler and let see if it's ok
-	tsc -out /dev/null $fileName.d.ts
+	$TSC -out /dev/null $fileName.d.ts
 done
 
 echo "Conversion OK"
 
 # The compilation is a part of the tests
-tsc tests.ts --module commonjs
+$TSC tests.ts --module commonjs
 echo "Compilation OK"
 
 # Run the unit tests
 echo "Running mocha tests"
-mocha tests.js
+$MOCHA tests.js

--- a/templates/interface.dust
+++ b/templates/interface.dust
@@ -7,7 +7,8 @@ declare module {fullPackageName} {
 		{/camelCaseGetSet}{#underscoreGetSet}
 		get_{name}() : {type|convertType}{rule|repeatedType};
 		set_{name}({name|firstLetterInLowerCase} : {type|convertType}{rule|repeatedType}): void;
-		{/underscoreGetSet}{/fields}
+		{/underscoreGetSet}{/fields}{#oneofsArray}{name}?: string
+		{/oneofsArray}
 	}
 	
 	{>builder:./}	

--- a/tests/oneof.proto
+++ b/tests/oneof.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message ContainsOneof {
+	oneof something {
+		string the_string = 1;
+		double the_number = 2;
+	}
+}


### PR DESCRIPTION
* Updated to ProtobufJs 5.0
* Make runTests work without any globally installed npm packages - install mocha and typescript, and get correct path to them.

I’m not sure how command.js is supposed to be generated – is there a script somewhere?
Just using `tsc command.ts` seems to have done it, but outputs 

    command.ts(26,1): error TS1148: Cannot compile modules unless the '--module' flag is provided. Consider setting the 'module' compiler option in a 'tsconfig.json' file.