### PR TITLE
Added option to disable generating ~Builder and ~Message definitions

### DIFF
--- a/command.js
+++ b/command.js
@@ -13,6 +13,10 @@ var argv = require('optimist')
     .alias('u', 'underscoreGetSet')
     .describe('u', 'Generate getter and setters in underscore notation')
     .default('u', false)
+    .boolean('b')
+    .alias('b', 'generateBuilders')
+    .describe('b', 'Generate ~Builder and ~Message definitions')
+    .default('b', true)
     .boolean('p')
     .alias('p', 'properties')
     .describe('p', 'Generate properties')
@@ -78,6 +82,7 @@ function generateNames(model, prefix, name) {
     model.camelCaseProperties = argv.camelCaseProperties;
     model.camelCaseGetSet = argv.camelCaseGetSet;
     model.underscoreGetSet = argv.underscoreGetSet;
+    model.generateBuilders = argv.generateBuilders;
     var newDefinitions = {};
     // Generate names for messages
     // Recursive call for all messages

--- a/command.ts
+++ b/command.ts
@@ -15,11 +15,15 @@ var argv = require('optimist')
     .alias('u', 'underscoreGetSet')
     .describe('u', 'Generate getter and setters in underscore notation')
     .default('u', false)
+    .boolean('b')
+    .alias('b', 'generateBuilders')
+    .describe('b', 'Generate ~Builder and ~Message definitions')
+    .default('b', true)
     .boolean('p')
     .alias('p', 'properties')
     .describe('p', 'Generate properties')
     .default('p', true)
-	.boolean('camelCaseProperties')
+    .boolean('camelCaseProperties')
     .describe('camelCaseProperties', 'Generate properties with camel case (either this or underscores - can’t be both)')
     .default('camelCaseProperties', false)
     .argv;
@@ -98,6 +102,7 @@ function generateNames (model : any, prefix : string, name : string = "") : void
 	model.camelCaseProperties = argv.camelCaseProperties;
 	model.camelCaseGetSet = argv.camelCaseGetSet;
 	model.underscoreGetSet = argv.underscoreGetSet;
+	model.generateBuilders = argv.generateBuilders;
 
 	var newDefinitions = {};
 

--- a/templates/interface.dust
+++ b/templates/interface.dust
@@ -25,7 +25,7 @@ declare module {fullPackageName} {
 		{/oneofsArray}
 	}
 
-	{>builder:./}
+	{?generateBuilders}{>builder:./}{/generateBuilders}
 }
 {#messages}
 {>interface:./}{/messages}{#enums}

--- a/templates/module.dust
+++ b/templates/module.dust
@@ -17,10 +17,10 @@ declare module {package} {
 		map : { [key: string]: ProtoBufMapItem<KeyType, ValueType> }
 	}
 	
-	export interface ProtoBufBuilder {
+	{?generateBuilders}export interface ProtoBufBuilder {
 		{#definitions}{name}: {type};
 		{/definitions}
-	}
+	}{/generateBuilders}
 }
 {#messages}
 {>interface:./}{/messages}{#enums}


### PR DESCRIPTION
Those of us who don't want or need `MyMessageBuilder` and `MyMessageMessage`, just `MyMessage`, can now supply `-b false` (default is true).