### PR TITLE
Option to handle properties for required fields (Proto2)

### DIFF
--- a/command.js
+++ b/command.js
@@ -21,6 +21,9 @@ var argv = require('optimist')
     .alias('p', 'properties')
     .describe('p', 'Generate properties')
     .default('p', true)
+    .boolean('explicitRequired')
+    .describe('explicitRequired', 'Mark required properties an required in interfaces')
+    .default('explicitRequired', false)
     .boolean('camelCaseProperties')
     .describe('camelCaseProperties', 'Generate properties with camel case (either this or underscores - can’t be both)')
     .default('camelCaseProperties', false)
@@ -82,6 +85,7 @@ function generateNames(model, prefix, name) {
     model.fullPackageName = prefix + (name != "." ? name : "");
     // Copies the settings (I'm lazy)
     model.properties = argv.properties;
+    model.explicitRequired = argv.explicitRequired;
     model.camelCaseProperties = argv.camelCaseProperties;
     model.camelCaseGetSet = argv.camelCaseGetSet;
     model.underscoreGetSet = argv.underscoreGetSet;

--- a/command.ts
+++ b/command.ts
@@ -23,6 +23,9 @@ var argv = require('optimist')
     .alias('p', 'properties')
     .describe('p', 'Generate properties')
     .default('p', true)
+    .boolean('explicitRequired')
+    .describe('explicitRequired', 'Mark required properties an required in interfaces')
+    .default('explicitRequired', false)
     .boolean('camelCaseProperties')
     .describe('camelCaseProperties', 'Generate properties with camel case (either this or underscores - can’t be both)')
     .default('camelCaseProperties', false)
@@ -102,6 +105,7 @@ function generateNames (model : any, prefix : string, name : string = "") : void
 
 	// Copies the settings (I'm lazy)
 	model.properties = argv.properties;
+	model.explicitRequired = argv.explicitRequired;
 	model.camelCaseProperties = argv.camelCaseProperties;
 	model.camelCaseGetSet = argv.camelCaseGetSet;
 	model.underscoreGetSet = argv.underscoreGetSet;

--- a/templates/interface.dust
+++ b/templates/interface.dust
@@ -5,7 +5,7 @@ declare module {fullPackageName} {
 		{#fields}
 
 		{#properties}
-		{#camelCaseProperties}{name|camelCase}{:else}{name}{/camelCaseProperties}?: {@eq key=rule value="map"}ProtoBufMap<{keytype|convertType}, {type|convertType}>{:else}{type|convertType}{rule|repeatedType}{/eq};
+		{#camelCaseProperties}{name|camelCase}{:else}{name}{/camelCaseProperties}{#explicitRequired}{@eq key=rule value="optional"}?{/eq}{:else}?{/explicitRequired}: {@eq key=rule value="map"}ProtoBufMap<{keytype|convertType}, {type|convertType}>{:else}{type|convertType}{rule|repeatedType}{/eq};
 		{/properties}
 
 		{#camelCaseGetSet}


### PR DESCRIPTION
This adds an option `--explicitRequired`. If enabled, it will mark properties in the generated interfaces as required, if the specification says that the field is required.

Of course, this is only useful for Protocol Buffers 2, so I am not sure if you want to merge it.
